### PR TITLE
fix: Swap npm install for npm ci

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,6 @@
 name: Node.js CI
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,6 +14,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Installing dependencies
-        run: npm install
+        run: npm ci
       - name: Testing
         run: npm test


### PR DESCRIPTION
Per documentation npm CI is faster at initialization of the
node_modules than npm install.

resolves: #4